### PR TITLE
bug fix: removed redundant check of `esp_secure_boot_verify_signature`

### DIFF
--- a/components/app_update/esp_ota_ops.c
+++ b/components/app_update/esp_ota_ops.c
@@ -429,13 +429,7 @@ esp_err_t esp_ota_set_boot_partition(const esp_partition_t *partition)
     if (image_validate(partition, ESP_IMAGE_VERIFY) != ESP_OK) {
         return ESP_ERR_OTA_VALIDATE_FAILED;
     }
-
-#ifdef CONFIG_SECURE_SIGNED_ON_UPDATE
-    esp_err_t ret = esp_secure_boot_verify_signature(partition->address, data.image_len);
-    if (ret != ESP_OK) {
-        return ESP_ERR_OTA_VALIDATE_FAILED;
-    }
-#endif
+    
     if (partition->type != ESP_PARTITION_TYPE_APP) {
         return ESP_ERR_INVALID_ARG;
     }


### PR DESCRIPTION


```
/opt/Espressif/esp-idf/components/app_update/esp_ota_ops.c: In function 'esp_ota_set_boot_partition':
/opt/Espressif/esp-idf/components/app_update/esp_ota_ops.c:434:74: error: 'data' undeclared (first use in this function)
     esp_err_t ret = esp_secure_boot_verify_signature(partition->address, data.image_len);
                                                                          ^
/opt/Espressif/esp-idf/components/app_update/esp_ota_ops.c:434:74: note: each undeclared identifier is reported only once fo
```
The above error was caused while building with SECURE_BOOT flags, removed it as it is unnecceassry (and buggy - data not declared). The  `image_validate` function already checks for `esp_secure_boot_verify_signature`